### PR TITLE
Support Xcode 11

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/.swiftpm/xcode/package.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Package.swift
+++ b/Package.swift
@@ -4,6 +4,7 @@ import PackageDescription
 
 let package = Package(
     name: "TOMLDecoder",
+    platforms: [.iOS(.v9), .tvOS(.v9), .watchOS(.v2), .macOS(.v10_10)],
     products: [
         .library(
             name: "TOMLDecoder",

--- a/Sources/TOMLDecoder/TOMLDecoder.swift
+++ b/Sources/TOMLDecoder/TOMLDecoder.swift
@@ -1200,7 +1200,7 @@ extension TOMLDecoder.KeyDecodingStrategy {
         let leadingUnderscoreRange = stringKey.startIndex..<firstNonUnderscore
         let trailingUnderscoreRange = stringKey.index(after: lastNonUnderscore)..<stringKey.endIndex
 
-        var components = stringKey[keyRange].split(separator: "_")
+        let components = stringKey[keyRange].split(separator: "_")
         let joinedString : String
         if components.count == 1 {
             // No underscores in key, leave the word as is - maybe already camel cased


### PR DESCRIPTION
Support Xcode 11. Don't worry, this project can be still built on Xcode 10.2. Current Swift syntax is still 5.0.

- Open this project with Xcode 11 then generates xcworkspace
- Add platforms to `Package.swift`
- Avoid warning