### PR TITLE
Fix DYLIB_INSTALL_NAME_BASE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 ## master
 
 - Fixed an issue where failure in single value decoding results in a crash (#19)
+- Restored Carthage support (#21, #22)

--- a/Resources/xcconfigs/UniversalFramework_Framework.xcconfig
+++ b/Resources/xcconfigs/UniversalFramework_Framework.xcconfig
@@ -32,3 +32,4 @@ ENABLE_BITCODE[sdk=appletvsimulator*]         = YES
 ENABLE_BITCODE[sdk=appletv*]                  = YES
 INFOPLIST_FILE = Resources/Info.plist
 PRODUCT_BUNDLE_IDENTIFIER = ca.duan.TOMLDeserializer
+DYLIB_INSTALL_NAME_BASE = @rpath


### PR DESCRIPTION
Apparently, Xcode fallback to an absolute path `/Library/Frameworks` for
this value. So if user choose to embed this framework, it won't be
there, therefore user's app won't launch.