### PR TITLE
Add bazel support

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -1,0 +1,18 @@
+name: Bazel Tests
+on: [push]
+jobs:
+  bazel-test:
+    name: Bazel tests
+    runs-on: macos-latest
+    steps:
+    - uses: bazel-contrib/setup-bazel@0.9.1
+      with:
+        bazelisk-cache: true
+        disk-cache: ${{ github.workflow }}
+        repository-cache: true
+    - name: Checkout source
+      uses: actions/checkout@v4
+    - name: Build everything
+      run: bazel build //...
+    - name: Run tests
+      run: bazel test //...

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -1,4 +1,4 @@
-name: CI Tests
+name: Swift Tests
 on: [push]
 jobs:
   swift-test:

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ Dependencies/TOMLDeserializer
 .swiftpm
 tmp
 /result
+/bazel-*
+MODULE.bazel.lock
+/.vscode

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,58 @@
+load("@build_bazel_rules_swift//swift:swift.bzl", "swift_library", "swift_test", "swift_binary")
+load("@bazel_skylib//rules:copy_directory.bzl", "copy_directory")
+
+swift_binary(
+    name = "compliance",
+    srcs = ["Sources/compliance/main.swift"],
+    deps = [
+        ":TOMLDecoder",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+swift_library(
+    name = "TOMLDecoder",
+    srcs = glob(["Sources/TOMLDecoder/**/*.swift"]),
+    deps = [
+        ":Deserializer",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+swift_library(
+    name = "Deserializer",
+    srcs = glob(["Sources/Deserializer/**/*.swift"]),
+    visibility = ["//visibility:private"],
+)
+
+swift_test(
+    name = "TOMLDecoderTests",
+    srcs = glob(["Tests/TOMLDecoderTests/**/*.swift"]),
+    deps = [":TOMLDecoder"],
+    visibility = ["//visibility:private"],
+)
+
+swift_test(
+    name = "DeserializerTests",
+    srcs = glob(["Tests/DeserializerTests/**/*.swift"]),
+    deps = [":Deserializer"],
+    data = [
+        ":valid_fixtures",
+        ":invalid_fixtures",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+copy_directory(
+    name = "valid_fixtures",
+    src = "Tests/DeserializerTests/valid_fixtures",
+    out = "Tests/DeserializerTests/valid_fixtures",
+    visibility = ["//visibility:private"],
+)
+
+copy_directory(
+    name = "invalid_fixtures",
+    src = "Tests/DeserializerTests/invalid_fixtures",
+    out = "Tests/DeserializerTests/invalid_fixtures",
+    visibility = ["//visibility:private"],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,9 @@
+module(
+    name = "swift-syntax",
+    version = "0",
+    compatibility_level = 1,
+)
+
+bazel_dep(name = "apple_support", version = "1.15.1", repo_name = "build_bazel_apple_support")
+bazel_dep(name = "rules_swift", version = "1.18.0", max_compatibility_level = 2, repo_name = "build_bazel_rules_swift")
+bazel_dep(name = "bazel_skylib", version = "1.7.1")


### PR DESCRIPTION
Targets mirrors those from `Package.swift`

Add CI that builds targets and runs tests

(is this enough for central registry?)