### PR TITLE
Improve parser for local date/time API

### DIFF
--- a/Sources/TOMLDecoder/DateTime.swift
+++ b/Sources/TOMLDecoder/DateTime.swift
@@ -275,7 +275,7 @@ public struct LocalTime: Equatable, Hashable, Sendable, Codable, CustomStringCon
     ///   - minute: The minute component of the local time.
     ///   - second: The second component of the local time.
     ///   - nanosecond: The fractional second component of the local time in nanoseconds.
-    public init(validatingHour hour: UInt8, minute: UInt8, second: UInt8, nanosecond: UInt32) throws(TOMLError) {
+    public init(validatingHour hour: UInt8, minute: UInt8, second: UInt8, nanosecond: UInt32 = 0) throws(TOMLError) {
         self.init(hour: hour, minute: minute, second: second, nanosecond: nanosecond)
         guard isValid else {
             throw TOMLError.invalidDateTimeComponents("Invalid local time components: \(hour):\(minute):\(second).\(nanosecond)")
@@ -292,7 +292,7 @@ public struct LocalTime: Equatable, Hashable, Sendable, Codable, CustomStringCon
     ///   - minute: The minute component of the local time.
     ///   - second: The second component of the local time.
     ///   - nanosecond: The fractional second component of the local time in nanoseconds.
-    public init(hour: UInt8, minute: UInt8, second: UInt8, nanosecond: UInt32) {
+    public init(hour: UInt8, minute: UInt8, second: UInt8, nanosecond: UInt32 = 0) {
         self.hour = hour
         self.minute = minute
         self.second = second

--- a/Sources/TOMLDecoder/TOMLArray.swift
+++ b/Sources/TOMLDecoder/TOMLArray.swift
@@ -62,31 +62,40 @@ public struct TOMLArray: Equatable, Sendable {
     }
 
     public func offsetDateTime(atIndex index: Int) throws(TOMLError) -> OffsetDateTime {
-        guard case let .leaf(.offsetDateTime(value)) = try element(atIndex: index) else {
+        guard case let .leaf(.dateTimeComponents(components)) = try element(atIndex: index) else {
             throw TOMLError.typeMismatchInArray(index: index, expected: "offset datetime")
         }
-        return value
+
+        switch (components.date, components.time, components.offset, components.features) {
+        case let (.some(date), .some(time), .some(offset), features):
+            return OffsetDateTime(date: date, time: time, offset: offset, features: features)
+        default:
+            throw TOMLError.typeMismatchInArray(index: index, expected: "offset datetime")
+        }
     }
 
-    public func localDateTime(atIndex index: Int) throws(TOMLError) -> LocalDateTime {
-        guard case let .leaf(.localDateTime(value)) = try element(atIndex: index) else {
+    public func localDateTime(atIndex index: Int, exactMatch: Bool = true) throws(TOMLError) -> LocalDateTime {
+        guard case let .leaf(.dateTimeComponents(components)) = try element(atIndex: index) else {
             throw TOMLError.typeMismatchInArray(index: index, expected: "local datetime")
         }
-        return value
+
+        return try components.localDateTime(exactMatch: exactMatch, error: TOMLError.typeMismatchInArray(index: index, expected: "local datetime"))
     }
 
-    public func localDate(atIndex index: Int) throws(TOMLError) -> LocalDate {
-        guard case let .leaf(.localDate(value)) = try element(atIndex: index) else {
+    public func localDate(atIndex index: Int, exactMatch: Bool = true) throws(TOMLError) -> LocalDate {
+        guard case let .leaf(.dateTimeComponents(components)) = try element(atIndex: index) else {
             throw TOMLError.typeMismatchInArray(index: index, expected: "local date")
         }
-        return value
+
+        return try components.localDate(exactMatch: exactMatch, error: TOMLError.typeMismatchInArray(index: index, expected: "local date"))
     }
 
-    public func localTime(atIndex index: Int) throws(TOMLError) -> LocalTime {
-        guard case let .leaf(.localTime(value)) = try element(atIndex: index) else {
+    public func localTime(atIndex index: Int, exactMatch: Bool = true) throws(TOMLError) -> LocalTime {
+        guard case let .leaf(.dateTimeComponents(components)) = try element(atIndex: index) else {
             throw TOMLError.typeMismatchInArray(index: index, expected: "local time")
         }
-        return value
+
+        return try components.localTime(exactMatch: exactMatch, error: TOMLError.typeMismatchInArray(index: index, expected: "local time"))
     }
 
     func array() throws(TOMLError) -> [Any] {

--- a/Sources/TOMLDecoder/TOMLTable.swift
+++ b/Sources/TOMLDecoder/TOMLTable.swift
@@ -90,59 +90,34 @@ public struct TOMLTable: Sendable, Equatable {
 
     public func offsetDateTime(forKey key: String) throws(TOMLError) -> OffsetDateTime {
         try value(forKey: key) { text throws(TOMLError) in
-            let datetime = try datetimeMaybe(lineNumber: nil, text)
-            switch (datetime.date, datetime.time, datetime.offset) {
+            let components = try datetimeMaybe(lineNumber: nil, text)
+            switch (components.date, components.time, components.offset) {
             case let (.some(date), .some(time), .some(offset)):
-                return OffsetDateTime(date: date, time: time, offset: offset, features: datetime.features)
+                return OffsetDateTime(date: date, time: time, offset: offset, features: components.features)
             default:
                 throw TOMLError.keyNotFoundInTable(key: key, type: "offset date-time")
             }
         }
     }
 
-    public func localDateTime(forKey key: String, strict: Bool = false) throws(TOMLError) -> LocalDateTime {
+    public func localDateTime(forKey key: String, exactMatch: Bool = true) throws(TOMLError) -> LocalDateTime {
         try value(forKey: key) { text throws(TOMLError) in
-            let datetime = try datetimeMaybe(lineNumber: nil, text)
-            switch (datetime.date, datetime.time, datetime.offset) {
-            case let (.some(date), .some(time), .some) where !strict:
-                return LocalDateTime(date: date, time: time)
-            case let (.some(date), .some(time), .none):
-                return LocalDateTime(date: date, time: time)
-            default:
-                throw TOMLError.keyNotFoundInTable(key: key, type: "local date-time")
-            }
+            let components = try datetimeMaybe(lineNumber: nil, text)
+            return try components.localDateTime(exactMatch: exactMatch, error: TOMLError.keyNotFoundInTable(key: key, type: "local date-time"))
         }
     }
 
-    public func localDate(forKey key: String, strict: Bool = false) throws(TOMLError) -> LocalDate {
+    public func localDate(forKey key: String, exactMatch: Bool = true) throws(TOMLError) -> LocalDate {
         try value(forKey: key) { text throws(TOMLError) in
-            let datetime = try datetimeMaybe(lineNumber: nil, text)
-            switch (datetime.date, datetime.time, datetime.offset) {
-            case let (.some(date), .some, .some) where !strict:
-                return date
-            case let (.some(date), .some, .none) where !strict:
-                return date
-            case let (.some(date), .none, .none):
-                return date
-            default:
-                throw TOMLError.keyNotFoundInTable(key: key, type: "local date")
-            }
+            let components = try datetimeMaybe(lineNumber: nil, text)
+            return try components.localDate(exactMatch: exactMatch, error: TOMLError.keyNotFoundInTable(key: key, type: "local date"))
         }
     }
 
-    public func localTime(forKey key: String, strict: Bool = false) throws(TOMLError) -> LocalTime {
+    public func localTime(forKey key: String, exactMatch: Bool = true) throws(TOMLError) -> LocalTime {
         try value(forKey: key) { text throws(TOMLError) in
-            let datetime = try datetimeMaybe(lineNumber: nil, text)
-            switch (datetime.date, datetime.time, datetime.offset) {
-            case let (.some, .some(time), .some) where !strict:
-                return time
-            case let (.some, .some(time), .none) where !strict:
-                return time
-            case let (.none, .some(time), .none):
-                return time
-            default:
-                throw TOMLError.keyNotFoundInTable(key: key, type: "local time")
-            }
+            let components = try datetimeMaybe(lineNumber: nil, text)
+            return try components.localTime(exactMatch: exactMatch, error: TOMLError.keyNotFoundInTable(key: key, type: "local time"))
         }
     }
 

--- a/Tests/TOMLDecoderTests/DateTimeExactMatchTests.swift
+++ b/Tests/TOMLDecoderTests/DateTimeExactMatchTests.swift
@@ -1,0 +1,106 @@
+import Testing
+import TOMLDecoder
+
+@Suite
+struct DateTimeExactMatchTests {
+    @Test(.tags(.local_date))
+    func `local date exact match`() throws {
+        let toml = """
+        date = 2021-01-01
+        date_with_time = 2021-01-01T01:02:03
+        date_with_offset = 2021-01-01T01:02:03+01:00
+        """
+
+        let table = try TOMLTable(source: toml)
+        let expectedDate = LocalDate(year: 2021, month: 1, day: 1)
+        #expect(try table.localDate(forKey: "date", exactMatch: true) == expectedDate)
+        #expect(try table.localDate(forKey: "date", exactMatch: false) == expectedDate)
+        #expect(throws: TOMLError.self) { try table.localDate(forKey: "date_with_time", exactMatch: true) }
+        #expect(try table.localDate(forKey: "date_with_time", exactMatch: false) == expectedDate)
+        #expect(throws: TOMLError.self) { try table.localDate(forKey: "date_with_offset", exactMatch: true) }
+        #expect(try table.localDate(forKey: "date_with_offset", exactMatch: false) == expectedDate)
+    }
+
+    @Test(.tags(.local_time))
+    func `local time exact match`() throws {
+        let toml = """
+        time = 01:02:03
+        time_with_date = 2021-01-01T01:02:03
+        time_with_offset = 2021-01-01T01:02:03+01:00
+        """
+
+        let table = try TOMLTable(source: toml)
+        let expectedTime = LocalTime(hour: 1, minute: 2, second: 3)
+        #expect(try table.localTime(forKey: "time", exactMatch: true) == expectedTime)
+        #expect(try table.localTime(forKey: "time", exactMatch: false) == expectedTime)
+        #expect(throws: TOMLError.self) { try table.localTime(forKey: "time_with_date", exactMatch: true) }
+        #expect(try table.localTime(forKey: "time_with_date", exactMatch: false) == expectedTime)
+        #expect(throws: TOMLError.self) { try table.localTime(forKey: "time_with_offset", exactMatch: true) }
+        #expect(try table.localTime(forKey: "time_with_offset", exactMatch: false) == expectedTime)
+    }
+
+    @Test(.tags(.local_datetime))
+    func `local datetime exact match`() throws {
+        let toml = """
+        datetime = 2021-01-01T01:02:03
+        datetime_with_offset = 2021-01-01T01:02:03+01:00
+        """
+
+        let table = try TOMLTable(source: toml)
+        let expectedDateTime = LocalDateTime(date: LocalDate(year: 2021, month: 1, day: 1), time: LocalTime(hour: 1, minute: 2, second: 3))
+
+        #expect(try table.localDateTime(forKey: "datetime", exactMatch: true) == expectedDateTime)
+        #expect(try table.localDateTime(forKey: "datetime", exactMatch: false) == expectedDateTime)
+        #expect(throws: TOMLError.self) { try table.localDateTime(forKey: "datetime_with_offset", exactMatch: true) }
+        #expect(try table.localDateTime(forKey: "datetime_with_offset", exactMatch: false) == expectedDateTime)
+    }
+
+    @Test(.tags(.local_date, .array))
+    func `local date exact match in array`() throws {
+        let toml = """
+        dates = [2021-01-01, 2021-01-01T01:02:03, 2021-01-01T01:02:03+01:00]
+        """
+
+        let table = try TOMLTable(source: toml)
+        let expectedDate = LocalDate(year: 2021, month: 1, day: 1)
+        let dates = try table.array(forKey: "dates")
+        #expect(try dates.localDate(atIndex: 0, exactMatch: true) == expectedDate)
+        #expect(try dates.localDate(atIndex: 0, exactMatch: false) == expectedDate)
+        #expect(throws: TOMLError.self) { try dates.localDate(atIndex: 1, exactMatch: true) }
+        #expect(try dates.localDate(atIndex: 1, exactMatch: false) == expectedDate)
+        #expect(throws: TOMLError.self) { try dates.localDate(atIndex: 2, exactMatch: true) }
+        #expect(try dates.localDate(atIndex: 2, exactMatch: false) == expectedDate)
+    }
+
+    @Test(.tags(.local_time, .array))
+    func `local time exact match in array`() throws {
+        let toml = """
+        times = [01:02:03, 2021-01-01T01:02:03, 2021-01-01T01:02:03+01:00]
+        """
+
+        let table = try TOMLTable(source: toml)
+        let expectedTime = LocalTime(hour: 1, minute: 2, second: 3)
+        let times = try table.array(forKey: "times")
+        #expect(try times.localTime(atIndex: 0, exactMatch: true) == expectedTime)
+        #expect(try times.localTime(atIndex: 0, exactMatch: false) == expectedTime)
+        #expect(throws: TOMLError.self) { try times.localTime(atIndex: 1, exactMatch: true) }
+        #expect(try times.localTime(atIndex: 1, exactMatch: false) == expectedTime)
+        #expect(throws: TOMLError.self) { try times.localTime(atIndex: 2, exactMatch: true) }
+        #expect(try times.localTime(atIndex: 2, exactMatch: false) == expectedTime)
+    }
+
+    @Test(.tags(.local_datetime, .array))
+    func `local datetime exact match in array`() throws {
+        let toml = """
+        datetimes = [2021-01-01T01:02:03, 2021-01-01T01:02:03+01:00]
+        """
+
+        let table = try TOMLTable(source: toml)
+        let expectedDateTime = LocalDateTime(date: LocalDate(year: 2021, month: 1, day: 1), time: LocalTime(hour: 1, minute: 2, second: 3))
+        let datetimes = try table.array(forKey: "datetimes")
+        #expect(try datetimes.localDateTime(atIndex: 0, exactMatch: true) == expectedDateTime)
+        #expect(try datetimes.localDateTime(atIndex: 0, exactMatch: false) == expectedDateTime)
+        #expect(throws: TOMLError.self) { try datetimes.localDateTime(atIndex: 1, exactMatch: true) }
+        #expect(try datetimes.localDateTime(atIndex: 1, exactMatch: false) == expectedDateTime)
+    }
+}


### PR DESCRIPTION
Add test for `x((forKey|atIndex):exactMatch:)`.
