### PR TITLE
Propagate line number in value parsing errors

### DIFF
--- a/Sources/TOMLDecoder/TOMLArray.swift
+++ b/Sources/TOMLDecoder/TOMLArray.swift
@@ -19,117 +19,127 @@ public struct TOMLArray: Equatable, Sendable {
     }
 
     public func array(atIndex index: Int) throws(TOMLError) -> TOMLArray {
-        guard case let .array(arrayIndex) = try element(atIndex: index) else {
-            throw TOMLError.typeMismatchInArray(index: index, expected: "array")
+        let element = try element(atIndex: index)
+        guard case let .array(_, arrayIndex) = element else {
+            throw TOMLError.typeMismatchInArray(lineNumber: element.lineNumber, index: index, expected: "array")
         }
 
         return TOMLArray(source: source, index: arrayIndex)
     }
 
     public func table(atIndex index: Int) throws(TOMLError) -> TOMLTable {
-        guard case let .table(tableIndex) = try element(atIndex: index) else {
-            throw TOMLError.typeMismatchInArray(index: index, expected: "table")
+        let element = try element(atIndex: index)
+        guard case let .table(_, tableIndex) = element else {
+            throw TOMLError.typeMismatchInArray(lineNumber: element.lineNumber, index: index, expected: "table")
         }
         return TOMLTable(source: source, index: tableIndex)
     }
 
     public func string(atIndex index: Int) throws(TOMLError) -> String {
-        guard case let .leaf(text) = try element(atIndex: index) else {
-            throw TOMLError.typeMismatchInArray(index: index, expected: "string")
+        let element = try element(atIndex: index)
+        guard case let .leaf(token) = element else {
+            throw TOMLError.typeMismatchInArray(lineNumber: element.lineNumber, index: index, expected: "string")
         }
-        guard let result = try stringMaybe(text) else {
-            throw TOMLError.typeMismatchInArray(index: index, expected: "string")
+        guard let result = try stringMaybe(token.text) else {
+            throw TOMLError.typeMismatchInArray(lineNumber: token.lineNumber, index: index, expected: "string")
         }
         return result
     }
 
     public func bool(atIndex index: Int) throws(TOMLError) -> Bool {
-        guard case let .leaf(text) = try element(atIndex: index) else {
-            throw TOMLError.typeMismatchInArray(index: index, expected: "bool")
+        let element = try element(atIndex: index)
+        guard case let .leaf(token) = element else {
+            throw TOMLError.typeMismatchInArray(lineNumber: element.lineNumber, index: index, expected: "bool")
         }
         do {
-            return try boolMaybe(text)
+            return try boolMaybe(token.text)
         } catch {
-            throw TOMLError.typeMismatchInArray(index: index, expected: "bool")
+            throw TOMLError.typeMismatchInArray(lineNumber: token.lineNumber, index: index, expected: "bool")
         }
     }
 
     public func integer(atIndex index: Int) throws(TOMLError) -> Int64 {
-        guard case let .leaf(text) = try element(atIndex: index) else {
-            throw TOMLError.typeMismatchInArray(index: index, expected: "integer")
+        let element = try element(atIndex: index)
+        guard case let .leaf(token) = element else {
+            throw TOMLError.typeMismatchInArray(lineNumber: element.lineNumber, index: index, expected: "integer")
         }
         do {
-            return try intMaybe(text, mustBeInt: true)
+            return try intMaybe(token.text, mustBeInt: true)
         } catch {
-            throw TOMLError.typeMismatchInArray(index: index, expected: "integer")
+            throw TOMLError.typeMismatchInArray(lineNumber: token.lineNumber, index: index, expected: "integer")
         }
     }
 
     public func float(atIndex index: Int) throws(TOMLError) -> Double {
-        guard case let .leaf(text) = try element(atIndex: index) else {
-            throw TOMLError.typeMismatchInArray(index: index, expected: "float")
+        let element = try element(atIndex: index)
+        guard case let .leaf(token) = element else {
+            throw TOMLError.typeMismatchInArray(lineNumber: element.lineNumber, index: index, expected: "float")
         }
         do {
-            return try floatMaybe(text, mustBeFloat: true)
+            return try floatMaybe(token.text, mustBeFloat: true)
         } catch {
-            throw TOMLError.typeMismatchInArray(index: index, expected: "float")
+            throw TOMLError.typeMismatchInArray(lineNumber: token.lineNumber, index: index, expected: "float")
         }
     }
 
     public func offsetDateTime(atIndex index: Int) throws(TOMLError) -> OffsetDateTime {
-        guard case let .leaf(text) = try element(atIndex: index) else {
-            throw TOMLError.typeMismatchInArray(index: index, expected: "offset datetime")
+        let element = try element(atIndex: index)
+        guard case let .leaf(token) = element else {
+            throw TOMLError.typeMismatchInArray(lineNumber: element.lineNumber, index: index, expected: "offset datetime")
         }
 
         do {
-            let components = try datetimeMaybe(lineNumber: nil, text)
+            let components = try datetimeMaybe(lineNumber: nil, token.text)
             switch (components.date, components.time, components.offset, components.features) {
             case let (.some(date), .some(time), .some(offset), features):
                 return OffsetDateTime(date: date, time: time, offset: offset, features: features)
             default:
-                throw TOMLError.typeMismatchInArray(index: index, expected: "offset datetime")
+                throw TOMLError.typeMismatchInArray(lineNumber: token.lineNumber, index: index, expected: "offset datetime")
             }
         } catch {
-            throw TOMLError.typeMismatchInArray(index: index, expected: "offset datetime")
+            throw TOMLError.typeMismatchInArray(lineNumber: token.lineNumber, index: index, expected: "offset datetime")
         }
     }
 
     public func localDateTime(atIndex index: Int, exactMatch: Bool = true) throws(TOMLError) -> LocalDateTime {
-        guard case let .leaf(text) = try element(atIndex: index) else {
-            throw TOMLError.typeMismatchInArray(index: index, expected: "local datetime")
+        let element = try element(atIndex: index)
+        guard case let .leaf(token) = element else {
+            throw TOMLError.typeMismatchInArray(lineNumber: element.lineNumber, index: index, expected: "local datetime")
         }
 
         do {
-            let components = try datetimeMaybe(lineNumber: nil, text)
-            return try components.localDateTime(exactMatch: exactMatch, error: TOMLError.typeMismatchInArray(index: index, expected: "local datetime"))
+            let components = try datetimeMaybe(lineNumber: nil, token.text)
+            return try components.localDateTime(exactMatch: exactMatch, error: TOMLError.typeMismatchInArray(lineNumber: token.lineNumber, index: index, expected: "local datetime"))
         } catch {
-            throw TOMLError.typeMismatchInArray(index: index, expected: "local datetime")
+            throw TOMLError.typeMismatchInArray(lineNumber: token.lineNumber, index: index, expected: "local datetime")
         }
     }
 
     public func localDate(atIndex index: Int, exactMatch: Bool = true) throws(TOMLError) -> LocalDate {
-        guard case let .leaf(text) = try element(atIndex: index) else {
-            throw TOMLError.typeMismatchInArray(index: index, expected: "local date")
+        let element = try element(atIndex: index)
+        guard case let .leaf(token) = element else {
+            throw TOMLError.typeMismatchInArray(lineNumber: element.lineNumber, index: index, expected: "local date")
         }
 
         do {
-            let components = try datetimeMaybe(lineNumber: nil, text)
-            return try components.localDate(exactMatch: exactMatch, error: TOMLError.typeMismatchInArray(index: index, expected: "local date"))
+            let components = try datetimeMaybe(lineNumber: nil, token.text)
+            return try components.localDate(exactMatch: exactMatch, error: TOMLError.typeMismatchInArray(lineNumber: token.lineNumber, index: index, expected: "local date"))
         } catch {
-            throw TOMLError.typeMismatchInArray(index: index, expected: "local date")
+            throw TOMLError.typeMismatchInArray(lineNumber: token.lineNumber, index: index, expected: "local date")
         }
     }
 
     public func localTime(atIndex index: Int, exactMatch: Bool = true) throws(TOMLError) -> LocalTime {
-        guard case let .leaf(text) = try element(atIndex: index) else {
-            throw TOMLError.typeMismatchInArray(index: index, expected: "local time")
+        let element = try element(atIndex: index)
+        guard case let .leaf(token) = element else {
+            throw TOMLError.typeMismatchInArray(lineNumber: element.lineNumber, index: index, expected: "local time")
         }
 
         do {
-            let components = try datetimeMaybe(lineNumber: nil, text)
-            return try components.localTime(exactMatch: exactMatch, error: TOMLError.typeMismatchInArray(index: index, expected: "local time"))
+            let components = try datetimeMaybe(lineNumber: nil, token.text)
+            return try components.localTime(exactMatch: exactMatch, error: TOMLError.typeMismatchInArray(lineNumber: token.lineNumber, index: index, expected: "local time"))
         } catch {
-            throw TOMLError.typeMismatchInArray(index: index, expected: "local time")
+            throw TOMLError.typeMismatchInArray(lineNumber: token.lineNumber, index: index, expected: "local time")
         }
     }
 

--- a/Sources/TOMLDecoder/TOMLError.swift
+++ b/Sources/TOMLDecoder/TOMLError.swift
@@ -12,7 +12,7 @@ public enum TOMLError: Error {
     case syntax(lineNumber: Int, message: String)
     case stringMissingClosingQuote(single: Bool)
     case arrayOutOfBound(index: Int, bound: Int)
-    case typeMismatchInArray(index: Int, expected: String)
+    case typeMismatchInArray(lineNumber: Int, index: Int, expected: String)
     case keyNotFoundInTable(key: String, type: String)
     case typeMismatchInTable(key: String, expected: String)
     case invalidNumber(reason: String)
@@ -20,8 +20,8 @@ public enum TOMLError: Error {
     case invalidFloat(reason: String)
     case invalidBool(String.UTF8View.SubSequence)
     case invalidDateTime(lineNumber: Int?, reason: String)
-    case invalidValueInTable(key: String)
-    case invalidValueInArray(index: Int)
+    case invalidValueInTable(lineNumber: Int, key: String)
+    case invalidValueInArray(lineNumber: Int, index: Int)
     case invalidDateTimeComponents(String)
 }
 
@@ -52,8 +52,8 @@ extension TOMLError: CustomStringConvertible {
             "String missing closing quote\(single ? " (single quoted)" : " (double quoted)") character."
         case let .arrayOutOfBound(index, bound):
             "Array index \(index) is out of bounds (0..<\(bound))."
-        case let .typeMismatchInArray(index, expected):
-            "Type mismatch at array index \(index): expected \(expected)."
+        case let .typeMismatchInArray(lineNumber, index, expected):
+            "Type mismatch at array index \(index) at line \(lineNumber): expected \(expected)."
         case let .keyNotFoundInTable(key, type):
             "Key '\(key)' not found in table of type \(type)."
         case let .typeMismatchInTable(key, expected):
@@ -68,10 +68,10 @@ extension TOMLError: CustomStringConvertible {
             "Invalid boolean value: \(value)."
         case let .invalidDateTime(lineNumber, reason):
             "Invalid date-time\(lineNumber.map { " at line \($0)" } ?? ""): \(reason)."
-        case let .invalidValueInTable(key):
-            "Invalid value in table for key '\(key)'."
-        case let .invalidValueInArray(index):
-            "Invalid value in array at index \(index)."
+        case let .invalidValueInTable(lineNumber, key):
+            "Invalid value in table for key '\(key)' at line \(lineNumber)."
+        case let .invalidValueInArray(lineNumber, index):
+            "Invalid value in array at index \(index) at line \(lineNumber)."
         case let .invalidDateTimeComponents(components):
             "Invalid date-time components: \(components)."
         case .notReallyCodable:

--- a/Sources/TOMLDecoder/TOMLTable.swift
+++ b/Sources/TOMLDecoder/TOMLTable.swift
@@ -157,7 +157,7 @@ public struct TOMLTable: Sendable, Equatable {
         let allPairs = source.keyValues
         for i in pairIndices {
             if allPairs[i].key == key {
-                return try parse(allPairs[i].value)
+                return try parse(allPairs[i].value.text)
             }
         }
 


### PR DESCRIPTION
By using Token more, we preserve more location info in the message.
