### PR TITLE
Conolidate leaf validation under Token

### DIFF
--- a/Sources/TOMLDecoder/DateTime.swift
+++ b/Sources/TOMLDecoder/DateTime.swift
@@ -61,16 +61,16 @@ public struct OffsetDateTime: Equatable, Hashable, Sendable, Codable, CustomStri
     public init(validatingDate date: LocalDate, time: LocalTime, offset: Int16, features: Features) throws(TOMLError) {
         self.init(date: date, time: time, offset: offset, features: features)
         guard date.isValid else {
-            throw TOMLError.invalidDateTimeComponents("Invalid local date: \(date)")
+            throw TOMLError(.invalidDateTimeComponents("Invalid local date: \(date)"))
         }
         guard time.isValid else {
-            throw TOMLError.invalidDateTimeComponents("Invalid local time: \(time)")
+            throw TOMLError(.invalidDateTimeComponents("Invalid local time: \(time)"))
         }
         guard offsetIsValid else {
-            throw TOMLError.invalidDateTimeComponents("Invalid offset: \(offset)")
+            throw TOMLError(.invalidDateTimeComponents("Invalid offset: \(offset)"))
         }
         guard featuresAreValid else {
-            throw TOMLError.invalidDateTimeComponents("Invalid features: \(features)")
+            throw TOMLError(.invalidDateTimeComponents("Invalid features: \(features)"))
         }
     }
 
@@ -234,10 +234,10 @@ public struct LocalDateTime: Equatable, Hashable, Sendable, Codable, CustomStrin
     public init(validatingDate date: LocalDate, time: LocalTime) throws(TOMLError) {
         self.init(date: date, time: time)
         guard date.isValid else {
-            throw TOMLError.invalidDateTimeComponents("Invalid local date: \(date)")
+            throw TOMLError(.invalidDateTimeComponents("Invalid local date: \(date)"))
         }
         guard time.isValid else {
-            throw TOMLError.invalidDateTimeComponents("Invalid local time: \(time)")
+            throw TOMLError(.invalidDateTimeComponents("Invalid local time: \(time)"))
         }
     }
 
@@ -278,7 +278,7 @@ public struct LocalTime: Equatable, Hashable, Sendable, Codable, CustomStringCon
     public init(validatingHour hour: UInt8, minute: UInt8, second: UInt8, nanosecond: UInt32 = 0) throws(TOMLError) {
         self.init(hour: hour, minute: minute, second: second, nanosecond: nanosecond)
         guard isValid else {
-            throw TOMLError.invalidDateTimeComponents("Invalid local time components: \(hour):\(minute):\(second).\(nanosecond)")
+            throw TOMLError(.invalidDateTimeComponents("Invalid local time components: \(hour):\(minute):\(second).\(nanosecond)"))
         }
     }
 
@@ -349,7 +349,7 @@ public struct LocalDate: Equatable, Hashable, Sendable, Codable, CustomStringCon
     public init(validatingYear year: UInt16, month: UInt8, day: UInt8) throws(TOMLError) {
         self.init(year: year, month: month, day: day)
         guard isValid else {
-            throw TOMLError.invalidDateTimeComponents("Invalid local date components: \(year)-\(month)-\(day)")
+            throw TOMLError(.invalidDateTimeComponents("Invalid local date components: \(year)-\(month)-\(day)"))
         }
     }
 

--- a/Sources/TOMLDecoder/TOMLError.swift
+++ b/Sources/TOMLDecoder/TOMLError.swift
@@ -1,33 +1,44 @@
-public enum TOMLError: Error {
-    case notReallyCodable
-    case invalidUTF8
-    case badKey(lineNumber: Int)
-    case expectedHexCharacters(UTF8.CodeUnit, Int)
-    case illegalEscapeCharacter(UTF8.CodeUnit)
-    case illegalUCSCode(UInt32)
-    case internalError(lineNumber: Int)
-    case invalidCharacter(UTF8.CodeUnit)
-    case invalidHexCharacters(UTF8.CodeUnit)
-    case keyExists(lineNumber: Int)
-    case syntax(lineNumber: Int, message: String)
-    case stringMissingClosingQuote(single: Bool)
-    case arrayOutOfBound(index: Int, bound: Int)
-    case typeMismatchInArray(lineNumber: Int, index: Int, expected: String)
-    case keyNotFoundInTable(key: String, type: String)
-    case typeMismatchInTable(key: String, expected: String)
-    case invalidNumber(reason: String)
-    case invalidInteger(reason: String)
-    case invalidFloat(reason: String)
-    case invalidBool(String.UTF8View.SubSequence)
-    case invalidDateTime(lineNumber: Int?, reason: String)
-    case invalidValueInTable(lineNumber: Int, key: String)
-    case invalidValueInArray(lineNumber: Int, index: Int)
-    case invalidDateTimeComponents(String)
+public struct TOMLError: Error {
+    let reason: Reason
+
+    init(_ reason: Reason) {
+        self.reason = reason
+    }
+
+    enum Reason {
+        case notReallyCodable
+        case invalidUTF8
+        case badKey(lineNumber: Int)
+        case expectedHexCharacters(UTF8.CodeUnit, Int)
+        case illegalEscapeCharacter(UTF8.CodeUnit)
+        case illegalUCSCode(UInt32)
+        case internalError(lineNumber: Int)
+        case invalidCharacter(UTF8.CodeUnit)
+        case invalidHexCharacters(UTF8.CodeUnit)
+        case keyExists(lineNumber: Int)
+        case syntax(lineNumber: Int, message: String)
+        case stringMissingClosingQuote(single: Bool)
+        case invalidString(context: TOMLKey, value: Token, reason: String)
+        case invalidDateTime2(context: TOMLKey, value: Token, reason: String)
+        case arrayOutOfBound(index: Int, bound: Int)
+        case typeMismatchInArray(lineNumber: Int, index: Int, expected: String)
+        case keyNotFoundInTable(key: String, type: String)
+        case typeMismatchInTable(key: String, expected: String)
+        case invalidNumber(reason: String)
+        case invalidInteger(context: TOMLKey, value: Token, reason: String)
+        case invalidFloat(reason: String)
+        case invalidFloat2(context: TOMLKey, value: Token, reason: String)
+        case invalidBool2(context: TOMLKey, value: Token)
+        case invalidDateTime(lineNumber: Int?, reason: String)
+        case invalidValueInTable(context: TOMLKey, token: Token)
+        case invalidValueInArray(context: TOMLKey, token: Token)
+        case invalidDateTimeComponents(String)
+    }
 }
 
 extension TOMLError: CustomStringConvertible {
     public var description: String {
-        switch self {
+        switch reason {
         case .invalidUTF8:
             "The given data was not valid UTF8."
         case let .badKey(lineNumber):
@@ -50,6 +61,15 @@ extension TOMLError: CustomStringConvertible {
             "Syntax error at line \(lineNumber): \(message)."
         case let .stringMissingClosingQuote(single):
             "String missing closing quote\(single ? " (single quoted)" : " (double quoted)") character."
+        case let .invalidString(context, value, reason):
+            switch context {
+            case let .string(key):
+                "Invalid string value '\(value.text)' for key '\(key)' on line \(value.lineNumber): \(reason)."
+            case let .int(index):
+                "Invalid string value '\(value.text)' for index \(index) on line \(value.lineNumber): \(reason)."
+            case .super:
+                "Invalid string value '\(value.text)' for 'super' on line \(value.lineNumber): \(reason)."
+            }
         case let .arrayOutOfBound(index, bound):
             "Array index \(index) is out of bounds (0..<\(bound))."
         case let .typeMismatchInArray(lineNumber, index, expected):
@@ -60,18 +80,64 @@ extension TOMLError: CustomStringConvertible {
             "Type mismatch at table key '\(key)': expected \(expected)."
         case let .invalidNumber(reason):
             "Invalid number: \(reason)."
-        case let .invalidInteger(reason):
-            "Invalid integer: \(reason)."
+        case let .invalidInteger(context, value, reason):
+            switch context {
+            case let .string(key):
+                "Invalid integer value '\(value.text)' for key '\(key)' on line \(value.lineNumber): \(reason)."
+            case let .int(index):
+                "Invalid integer value '\(value.text)' for index \(index) on line \(value.lineNumber): \(reason)."
+            case .super:
+                "Invalid integer value '\(value.text)' for 'super' on line \(value.lineNumber): \(reason)."
+            }
         case let .invalidFloat(reason):
             "Invalid float: \(reason)."
-        case let .invalidBool(value):
-            "Invalid boolean value: \(value)."
+        case let .invalidFloat2(context, value, reason):
+            switch context {
+            case let .string(key):
+                "Invalid float value '\(value.text)' for key '\(key)' on line \(value.lineNumber): \(reason)."
+            case let .int(index):
+                "Invalid float value '\(value.text)' for index \(index) on line \(value.lineNumber): \(reason)."
+            case .super:
+                "Invalid float value '\(value.text)' for 'super' on line \(value.lineNumber): \(reason)."
+            }
+        case let .invalidBool2(context, value):
+            switch context {
+            case let .string(key):
+                "Invalid boolean value '\(value.text)' for key '\(key)' on line \(value.lineNumber)."
+            case let .int(index):
+                "Invalid boolean value '\(value.text)' for index \(index) on line \(value.lineNumber)."
+            case .super:
+                "Invalid boolean value '\(value.text)' for 'super' on line \(value.lineNumber)."
+            }
+        case let .invalidDateTime2(context, value, reason):
+            switch context {
+            case let .string(key):
+                "Invalid date-time value '\(value.text)' for key '\(key)' on line \(value.lineNumber): \(reason)."
+            case let .int(index):
+                "Invalid date-time value '\(value.text)' for index \(index) on line \(value.lineNumber): \(reason)."
+            case .super:
+                "Invalid date-time value '\(value.text)' for 'super' on line \(value.lineNumber): \(reason)."
+            }
         case let .invalidDateTime(lineNumber, reason):
             "Invalid date-time\(lineNumber.map { " at line \($0)" } ?? ""): \(reason)."
-        case let .invalidValueInTable(lineNumber, key):
-            "Invalid value in table for key '\(key)' at line \(lineNumber)."
-        case let .invalidValueInArray(lineNumber, index):
-            "Invalid value in array at index \(index) at line \(lineNumber)."
+        case let .invalidValueInTable(context, value):
+            switch context {
+            case let .string(key):
+                "Invalid value in table for key '\(key)' at line \(value.lineNumber)."
+            case let .int(index):
+                "Invalid value in table for index \(index) at line \(value.lineNumber)."
+            case .super:
+                "Invalid value in table for 'super' at line \(value.lineNumber)."
+            }
+        case let .invalidValueInArray(context, value):
+            switch context {
+            case let .string(key):
+                "Invalid value in array for key '\(key)' at line \(value.lineNumber)."
+            case let .int(index):
+                "Invalid value in array for index \(index) at line \(value.lineNumber)."
+            case .super:
+                "Invalid value in array for 'super' at line \(value.lineNumber)."
+            }
         case let .invalidDateTimeComponents(components):
             "Invalid date-time components: \(components)."
         case .notReallyCodable:


### PR DESCRIPTION
`Token` is a natural point to organize all leaf validation logic.
The validation are all intented with a type in mind
except for the case where we blanket validate for everything.
So the methods for each type should be throwing
and caller can decide whether to ignore the thrown error
and move on to the next candidate.

Token being the funnel point also improves error messages.

The only downside is we are passing more than 2 String indices
around now.
So that might be slower.
