### PR TITLE
Use macOS 26 for docs deployment

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   deploy-docs:
     name: Generate and Deploy
-    runs-on: macos-latest
+    runs-on: macos-26
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- update the documentation deployment workflow to use the macOS 26 runner

## Testing
- not run (not needed for this change)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6930858984dc8320a8ed8ad9021e26ef)