### PR TITLE
Align Apple simulator coverage to prior OS generation

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -2,17 +2,74 @@ name: Swift Tests
 on: [push]
 jobs:
   swift-test:
-    name: Swift ${{ matrix.swift }} on ${{ matrix.os }}
+    name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        swift: ["6.2"]
+        include:
+          - name: Swift 6.2 on Ubuntu 24.04
+            os: ubuntu-24.04
+            swift: "6.2"
+            test_command: swift test
+            xcode_path: ""
+          - name: Swift 6.2 on Windows 2022
+            os: windows-2022
+            swift: "6.2"
+            test_command: swift test
+            xcode_path: ""
+          - name: Swift 6.2 on macOS 15 - macOS
+            os: macos-15
+            swift: "6.2"
+            test_command: swift test
+            xcode_path: /Applications/Xcode_16.4.0.app
+          - name: Swift 6.2 on macOS 26 - iOS
+            os: macos-26
+            swift: "6.2"
+            test_command: xcodebuild test -scheme TOMLDecoder-Package -destination "platform=iOS Simulator,name=iPhone 15"
+            xcode_path: /Applications/Xcode_26.1.app
+          - name: Swift 6.2 on macOS 15 - iOS (18.x)
+            os: macos-15
+            swift: "6.2"
+            test_command: xcodebuild test -scheme TOMLDecoder-Package -destination "platform=iOS Simulator,OS=18.0,name=iPhone 15"
+            xcode_path: /Applications/Xcode_16.4.0.app
+          - name: Swift 6.2 on macOS 26 - tvOS
+            os: macos-26
+            swift: "6.2"
+            test_command: xcodebuild test -scheme TOMLDecoder-Package -destination "platform=tvOS Simulator,name=Apple TV"
+            xcode_path: /Applications/Xcode_26.1.app
+          - name: Swift 6.2 on macOS 15 - tvOS (18.x)
+            os: macos-15
+            swift: "6.2"
+            test_command: xcodebuild test -scheme TOMLDecoder-Package -destination "platform=tvOS Simulator,OS=18.0,name=Apple TV"
+            xcode_path: /Applications/Xcode_16.4.0.app
+          - name: Swift 6.2 on macOS 26 - watchOS
+            os: macos-26
+            swift: "6.2"
+            test_command: xcodebuild test -scheme TOMLDecoder-Package -destination "platform=watchOS Simulator,name=Apple Watch Series 9 (45mm)"
+            xcode_path: /Applications/Xcode_26.1.app
+          - name: Swift 6.2 on macOS 15 - watchOS (11.x)
+            os: macos-15
+            swift: "6.2"
+            test_command: xcodebuild test -scheme TOMLDecoder-Package -destination "platform=watchOS Simulator,OS=11.0,name=Apple Watch Series 9 (45mm)"
+            xcode_path: /Applications/Xcode_16.4.0.app
+          - name: Swift 6.2 on macOS 26 - visionOS
+            os: macos-26
+            swift: "6.2"
+            test_command: xcodebuild test -scheme TOMLDecoder-Package -destination "platform=visionOS Simulator,name=Apple Vision Pro"
+            xcode_path: /Applications/Xcode_26.1.app
+          - name: Swift 6.2 on macOS 15 - visionOS (2.x)
+            os: macos-15
+            swift: "6.2"
+            test_command: xcodebuild test -scheme TOMLDecoder-Package -destination "platform=visionOS Simulator,OS=2.0,name=Apple Vision Pro"
+            xcode_path: /Applications/Xcode_16.4.0.app
     steps:
     - uses: SwiftyLab/setup-swift@latest
       with:
         swift-version: ${{ matrix.swift }}
     - name: Checkout source
       uses: actions/checkout@v2
+    - name: Select Xcode
+      if: runner.os == 'macOS'
+      run: sudo xcode-select -s "${{ matrix.xcode_path }}"
     - name: Run tests
-      run: swift test
+      run: ${{ matrix.test_command }}


### PR DESCRIPTION
- align Apple simulator coverage to only one generation behind current hosts by using iOS/tvOS/watchOS 18/11 era and visionOS 2 on macOS 15
- add macOS 26 iOS simulator job to complement existing latest-platform coverage
- select the intended Xcode per macOS host and simplify Apple platform job names

Closes #197 