### PR TITLE
Split the offset date-time strategies

### DIFF
--- a/Sources/TOMLDecoder/TOMLSingleValueDecodingContainer.Generated.swift
+++ b/Sources/TOMLDecoder/TOMLSingleValueDecodingContainer.Generated.swift
@@ -208,7 +208,7 @@ extension _TOMLDecoder: SingleValueDecodingContainer {
             return try token.unpackFloat(source: source, context: context)
         } catch let floatError {
             do {
-                return try Double(from: decode(OffsetDateTime.self), strategy: strategy.offsetDateTime)
+                return try Double(from: decode(OffsetDateTime.self), strategy: strategy.timeInterval)
             } catch let error as DecodingError {
                 throw error
             } catch {
@@ -325,28 +325,22 @@ extension _TOMLDecoder {
             throw DecodingError.valueNotFound(Date.self, DecodingError.Context(codingPath: codingPath, debugDescription: "No date found."))
         }
 
-        switch strategy.offsetDateTime {
-        case .intervalSince1970:
-            let float = try decode(Double.self)
-            return Date(timeIntervalSince1970: float)
-        case .intervalSince2001:
-            let float = try decode(Double.self)
-            return Date(timeIntervalSinceReferenceDate: float)
-        case .dateFromGregorianCalendar:
+        switch strategy.date {
+        case .gregorianCalendar:
             do {
                 let offsetDateTime = try decode(OffsetDateTime.self)
                 return Date(offsetDateTime: offsetDateTime, calendar: Calendar(identifier: .gregorian))
             } catch {
                 throw DecodingError.valueNotFound(Date.self, DecodingError.Context(codingPath: codingPath, debugDescription: "\(error)", underlyingError: error))
             }
-        case let .dateFromCalendar(identifier):
+        case let .calendar(identifiedBy: identifier):
             do {
                 let offsetDateTime = try decode(OffsetDateTime.self)
                 return Date(offsetDateTime: offsetDateTime, calendar: Calendar(identifier: identifier))
             } catch {
                 throw DecodingError.valueNotFound(Date.self, DecodingError.Context(codingPath: codingPath, debugDescription: "\(error)", underlyingError: error))
             }
-        case .dateFromProlepticGregorianCalendar:
+        case .prolepticGregorianCalendar:
             do {
                 let offsetDateTime = try decode(OffsetDateTime.self)
                 return Date(timeIntervalSinceReferenceDate: offsetDateTime.timeIntervalSince2001)

--- a/Sources/TOMLDecoder/_TOMLDecoder.swift
+++ b/Sources/TOMLDecoder/_TOMLDecoder.swift
@@ -65,17 +65,12 @@ final class _TOMLDecoder: Decoder {
 }
 
 extension TimeInterval {
-    init(from offsetDateTime: OffsetDateTime, strategy: TOMLDecoder.Strategy.OffsetDateTime) throws {
+    init(from offsetDateTime: OffsetDateTime, strategy: TOMLDecoder.TimeIntervalStrategy) throws {
         switch strategy {
-        case .intervalSince1970:
+        case .since1970:
             self = offsetDateTime.timeIntervalSince1970
-        case .intervalSince2001:
+        case .since2001:
             self = offsetDateTime.timeIntervalSince2001
-        default:
-            throw DecodingError.dataCorrupted(DecodingError.Context(
-                codingPath: [],
-                debugDescription: "Invalid strategy \(strategy) for OffsetDateTime conversion to TimeInterval",
-            ))
         }
     }
 }

--- a/Sources/TOMLDecoder/gyb/TOMLSingleValueDecodingContainer.swift.gyb
+++ b/Sources/TOMLDecoder/gyb/TOMLSingleValueDecodingContainer.swift.gyb
@@ -54,7 +54,7 @@ extension _TOMLDecoder: SingleValueDecodingContainer {
             return try token.unpackFloat(source: source, context: context)
         } catch let floatError {
             do {
-                return try Double(from: decode(OffsetDateTime.self), strategy: strategy.offsetDateTime)
+                return try Double(from: decode(OffsetDateTime.self), strategy: strategy.timeInterval)
             } catch let error as DecodingError {
                 throw error
             } catch {
@@ -147,28 +147,22 @@ extension _TOMLDecoder {
             throw DecodingError.valueNotFound(Date.self, DecodingError.Context(codingPath: codingPath, debugDescription: "No date found."))
         }
 
-        switch strategy.offsetDateTime {
-        case .intervalSince1970:
-            let float = try decode(Double.self)
-            return Date(timeIntervalSince1970: float)
-        case .intervalSince2001:
-            let float = try decode(Double.self)
-            return Date(timeIntervalSinceReferenceDate: float)
-        case .dateFromGregorianCalendar:
+        switch strategy.date {
+        case .gregorianCalendar:
             do {
                 let offsetDateTime = try decode(OffsetDateTime.self)
                 return Date(offsetDateTime: offsetDateTime, calendar: Calendar(identifier: .gregorian))
             } catch {
                 throw DecodingError.valueNotFound(Date.self, DecodingError.Context(codingPath: codingPath, debugDescription: "\(error)", underlyingError: error))
             }
-        case let .dateFromCalendar(identifier):
+        case let .calendar(identifiedBy: identifier):
             do {
                 let offsetDateTime = try decode(OffsetDateTime.self)
                 return Date(offsetDateTime: offsetDateTime, calendar: Calendar(identifier: identifier))
             } catch {
                 throw DecodingError.valueNotFound(Date.self, DecodingError.Context(codingPath: codingPath, debugDescription: "\(error)", underlyingError: error))
             }
-        case .dateFromProlepticGregorianCalendar:
+        case .prolepticGregorianCalendar:
             do {
                 let offsetDateTime = try decode(OffsetDateTime.self)
                 return Date(timeIntervalSinceReferenceDate: offsetDateTime.timeIntervalSince2001)

--- a/TOMLDecoder.docc/TOMLDecoder.md
+++ b/TOMLDecoder.docc/TOMLDecoder.md
@@ -42,8 +42,9 @@ the decoder's behaviors.
 - ``TOMLDecoder``
 - ``TOMLDecoder/isLenient``
 - ``TOMLDecoder/Strategy``
-- ``TOMLDecoder/Strategy/Key``
-- ``TOMLDecoder/Strategy/OffsetDateTime``
+- ``TOMLDecoder/KeyStrategy``
+- ``TOMLDecoder/TimeIntervalStrategy``
+- ``TOMLDecoder/DateStrategy``
 
 ### Deserializing TOML
 

--- a/Tests/TOMLDecoderTests/DateStrategyTests.swift
+++ b/Tests/TOMLDecoderTests/DateStrategyTests.swift
@@ -61,7 +61,7 @@ struct DateStrategyTests {
         """
 
         var decoder = TOMLDecoder()
-        decoder.strategy.offsetDateTime = .intervalSince1970
+        decoder.strategy.timeInterval = .since1970
         let result = try decoder.decode(Test.self, from: toml)
         #expect(result.datetime == 1_609_504_440.000567)
     }
@@ -77,7 +77,7 @@ struct DateStrategyTests {
         """
 
         var decoder = TOMLDecoder()
-        decoder.strategy.offsetDateTime = .intervalSince2001
+        decoder.strategy.timeInterval = .since2001
         let result = try decoder.decode(Test.self, from: toml)
         #expect(result.datetime == 631_197_240.000567)
     }
@@ -93,7 +93,7 @@ struct DateStrategyTests {
         """
 
         var decoder = TOMLDecoder()
-        decoder.strategy.offsetDateTime = .dateFromProlepticGregorianCalendar
+        decoder.strategy.date = .prolepticGregorianCalendar
         let result = try decoder.decode(Test.self, from: toml)
         #expect(result.datetime.timeIntervalSince1970 == -61_504_399_559.999435)
     }
@@ -109,7 +109,7 @@ struct DateStrategyTests {
         """
 
         var decoder = TOMLDecoder()
-        decoder.strategy.offsetDateTime = .dateFromCalendar(identifiedBy: .gregorian)
+        decoder.strategy.date = .calendar(identifiedBy: .gregorian)
         let result = try decoder.decode(Test.self, from: toml)
         #expect(result.datetime.timeIntervalSince1970 == 1_609_504_440.000567)
     }
@@ -180,7 +180,7 @@ struct DateStrategyTests {
         """
 
         var decoder = TOMLDecoder()
-        decoder.strategy.offsetDateTime = .intervalSince1970
+        decoder.strategy.timeInterval = .since1970
         let result = try decoder.decode(Test.self, from: toml)
         #expect(result.datetimes == [1_609_504_440.000567])
     }
@@ -196,7 +196,7 @@ struct DateStrategyTests {
         """
 
         var decoder = TOMLDecoder()
-        decoder.strategy.offsetDateTime = .intervalSince2001
+        decoder.strategy.timeInterval = .since2001
         let result = try decoder.decode(Test.self, from: toml)
         #expect(result.datetimes == [631_197_240.000567])
     }
@@ -212,7 +212,7 @@ struct DateStrategyTests {
         """
 
         var decoder = TOMLDecoder()
-        decoder.strategy.offsetDateTime = .dateFromProlepticGregorianCalendar
+        decoder.strategy.date = .prolepticGregorianCalendar
         let result = try decoder.decode(Test.self, from: toml)
         #expect(result.datetimes.map(\.timeIntervalSince1970) == [-61_504_399_559.999435])
     }
@@ -228,7 +228,7 @@ struct DateStrategyTests {
         """
 
         var decoder = TOMLDecoder()
-        decoder.strategy.offsetDateTime = .dateFromCalendar(identifiedBy: .gregorian)
+        decoder.strategy.date = .calendar(identifiedBy: .gregorian)
         let result = try decoder.decode(Test.self, from: toml)
         #expect(result.datetimes.map(\.timeIntervalSince1970) == [1_609_504_440.000567])
     }


### PR DESCRIPTION
... into a strategy for TimeInterval, and a strategy for Date.

This is because the preferences for decoding the 2 are agnostic.
It's valid to want some offset date-time to be interperted as time
interval/double, and some as dates. And both are also agnostic to
using `TOMLDecoder.OffsetDateTime` directely.

Give the strategies a shallower parent type, and include the word
"Strategy" as suffix in their names. This avoids confusion between,
for example, `Fonudation.TimeInterval`, and
`TOMLDecoder.Strategy.TimeInterval`, when the module/namespace is
elided.

Also add docs.
