### PR TITLE
Reduce number of sim tests

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -75,7 +75,7 @@ jobs:
           xcodebuild -scheme TOMLDecoder-Package -destination "${{ matrix.destination }}" -sdk "${{ matrix.sdk }}" test
 
   swift-test-simulator-backdeploy:
-    name: iOS 17.0 (Swift 6.0)
+    name: iOS 17.0.1 (Swift 6.0)
     runs-on: macos-14
     strategy:
       matrix:
@@ -90,17 +90,6 @@ jobs:
         run: sudo xcode-select -s /Applications/Xcode_16.1.app
       - name: Checkout source
         uses: actions/checkout@v4
-      - name: Cache exported simulator runtime
-        id: cache-runtime
-        uses: actions/cache@v4
-        with:
-          path: ${{ runner.temp }}/simruntimes/${{ matrix.platform }}/${{ matrix.os_version }}
-          key: simruntime-${{ runner.os }}-xcode26_1_1-${{ matrix.platform }}-${{ matrix.os_version }}
-      - name: Ensure simulator runtime and device exist
-        env:
-          SIMRUNTIME_EXPORT_BASE: ${{ runner.temp }}/simruntimes
-        run: |
-          Scripts/ensure-simulator.sh "${{ matrix.platform }}" "${{ matrix.os_version }}" "${{ matrix.destination }}" "${{ matrix.device_type_id }}"
       - name: Run simulator test
         run: |
           xcodebuild -scheme TOMLDecoder-Package -destination "${{ matrix.destination }}" -sdk "${{ matrix.sdk }}" test


### PR DESCRIPTION
Reduce to only testing on latest SDK + latest runtime.
Have one case that's on older SDK with even older runtime.
