### PR TITLE
Optimize scanString with UnsafePointer lookup

### DIFF
--- a/Sources/TOMLDecoder/ParserImplementation.Generated.swift
+++ b/Sources/TOMLDecoder/ParserImplementation.Generated.swift
@@ -27,7 +27,7 @@ extension Parser {
 
     @available(iOS 26, macOS 26, watchOS 26, tvOS 26, visionOS 26, *)
     mutating func nextToken(bytes: borrowing Span<UInt8>, isDotSpecial: Bool) throws(TOMLError) {
-        var lineNumber = currentLineNumber
+        let lineNumber = currentLineNumber
         var position = cursor
 
         @inline(__always)
@@ -129,12 +129,7 @@ extension Parser {
                     var index = start + 1
                     while index < range.upperBound {
                         let ch = bytes[index]
-                        if (ch >= CodeUnits.lowerA && ch <= CodeUnits.lowerZ) ||
-                            (ch >= CodeUnits.upperA && ch <= CodeUnits.upperZ) ||
-                            (ch >= CodeUnits.number0 && ch <= CodeUnits.number9) ||
-                            ch == CodeUnits.underscore ||
-                            ch == CodeUnits.minus
-                        {
+                        if CodeUnits.isBareKeyChar[Int(ch)] {
                             index += 1
                             continue
                         }
@@ -1734,7 +1729,7 @@ extension Parser {
 
     @available(iOS 13, macOS 10.15, watchOS 6, tvOS 13, visionOS 1, *)
     mutating func nextToken(bytes: UnsafeBufferPointer<UInt8>, isDotSpecial: Bool) throws(TOMLError) {
-        var lineNumber = currentLineNumber
+        let lineNumber = currentLineNumber
         var position = cursor
 
         @inline(__always)
@@ -1836,12 +1831,7 @@ extension Parser {
                     var index = start + 1
                     while index < range.upperBound {
                         let ch = bytes[index]
-                        if (ch >= CodeUnits.lowerA && ch <= CodeUnits.lowerZ) ||
-                            (ch >= CodeUnits.upperA && ch <= CodeUnits.upperZ) ||
-                            (ch >= CodeUnits.number0 && ch <= CodeUnits.number9) ||
-                            ch == CodeUnits.underscore ||
-                            ch == CodeUnits.minus
-                        {
+                        if CodeUnits.isBareKeyChar[Int(ch)] {
                             index += 1
                             continue
                         }

--- a/Sources/TOMLDecoder/Parsing/Constants.swift
+++ b/Sources/TOMLDecoder/Parsing/Constants.swift
@@ -47,6 +47,23 @@ enum CodeUnits {
     static let upperU: UTF8.CodeUnit = 85
     static let upperZ: UTF8.CodeUnit = 90
 
+    nonisolated(unsafe) static let isBareKeyChar: UnsafePointer<Bool> = {
+        let ptr = UnsafeMutablePointer<Bool>.allocate(capacity: 256)
+        ptr.initialize(repeating: false, count: 256)
+        for i in 0 ..< 256 {
+            let ch = UTF8.CodeUnit(i)
+            if (ch >= CodeUnits.lowerA && ch <= CodeUnits.lowerZ) ||
+                (ch >= CodeUnits.upperA && ch <= CodeUnits.upperZ) ||
+                (ch >= CodeUnits.number0 && ch <= CodeUnits.number9) ||
+                ch == CodeUnits.underscore ||
+                ch == CodeUnits.minus
+            {
+                ptr[i] = true
+            }
+        }
+        return UnsafePointer(ptr)
+    }()
+
     static let null: UTF8.CodeUnit = 0x00
     static let unitSeparator: UTF8.CodeUnit = 0x1F
     static let delete: UTF8.CodeUnit = 0x7F

--- a/Sources/TOMLDecoder/gyb/ParserImplementation.swift.gyb
+++ b/Sources/TOMLDecoder/gyb/ParserImplementation.swift.gyb
@@ -40,7 +40,7 @@ extension Parser {
 
     ${availability}
     mutating func nextToken(bytes: ${byte_type}, isDotSpecial: Bool) throws(TOMLError) {
-        var lineNumber = currentLineNumber
+        let lineNumber = currentLineNumber
         var position = cursor
 
         @inline(__always)
@@ -142,12 +142,7 @@ extension Parser {
                     var index = start + 1
                     while index < range.upperBound {
                         let ch = bytes[index]
-                        if (ch >= CodeUnits.lowerA && ch <= CodeUnits.lowerZ) ||
-                            (ch >= CodeUnits.upperA && ch <= CodeUnits.upperZ) ||
-                            (ch >= CodeUnits.number0 && ch <= CodeUnits.number9) ||
-                            ch == CodeUnits.underscore ||
-                            ch == CodeUnits.minus
-                        {
+                        if CodeUnits.isBareKeyChar[Int(ch)] {
                             index += 1
                             continue
                         }


### PR DESCRIPTION
Replaced character ranges and comparisons in `scanString` with a 256-element `UnsafePointer<Bool>` lookup table (`CodeUnits.isBareKeyChar`) to reduce branching and eliminate array bounds checking overhead during bare key parsing.
