### PR TITLE
Skip consecutive whitespace in tokenizer

### DIFF
--- a/Sources/TOMLDecoder/ParserImplementation.Generated.swift
+++ b/Sources/TOMLDecoder/ParserImplementation.Generated.swift
@@ -114,8 +114,15 @@ extension Parser {
                         ))
                 }
             } else if ch == CodeUnits.space || ch == CodeUnits.tab {
-                // ignore white spaces
+                // Skip consecutive whitespace
                 position += 1
+                while position < bytes.count {
+                    let ws = bytes[position]
+                    if ws != CodeUnits.space, ws != CodeUnits.tab {
+                        break
+                    }
+                    position += 1
+                }
                 continue
             }
 
@@ -1836,8 +1843,15 @@ extension Parser {
                         ))
                 }
             } else if ch == CodeUnits.space || ch == CodeUnits.tab {
-                // ignore white spaces
+                // Skip consecutive whitespace
                 position += 1
+                while position < bytes.count {
+                    let ws = bytes[position]
+                    if ws != CodeUnits.space, ws != CodeUnits.tab {
+                        break
+                    }
+                    position += 1
+                }
                 continue
             }
 

--- a/Sources/TOMLDecoder/gyb/ParserImplementation.swift.gyb
+++ b/Sources/TOMLDecoder/gyb/ParserImplementation.swift.gyb
@@ -127,8 +127,15 @@ extension Parser {
                         ))
                 }
             } else if ch == CodeUnits.space || ch == CodeUnits.tab {
-                // ignore white spaces
+                // Skip consecutive whitespace
                 position += 1
+                while position < bytes.count {
+                    let ws = bytes[position]
+                    if ws != CodeUnits.space, ws != CodeUnits.tab {
+                        break
+                    }
+                    position += 1
+                }
                 continue
             }
 


### PR DESCRIPTION
Modified whitespace handling in nextToken to skip consecutive whitespace
characters in a single inner loop rather than handling them one at a time.

This reduces main loop iterations for files with multiple consecutive spaces.
