### PR TITLE
Compute key hashes during normalization

### DIFF
--- a/Sources/TOMLDecoder/Parsing/Constants.swift
+++ b/Sources/TOMLDecoder/Parsing/Constants.swift
@@ -101,3 +101,28 @@ extension UTF8.CodeUnit {
             || CodeUnits.upperA <= self && self <= CodeUnits.upperF
     }
 }
+
+let keyHashOffsetBasis: UInt64 = 0xCBF2_9CE4_8422_2325
+let keyHashPrime: UInt64 = 0x100_0000_01B3
+
+@inline(__always)
+func computeKeyHash(bytes: UnsafeBufferPointer<UInt8>, start: Int, end: Int) -> Int {
+    var hash = keyHashOffsetBasis
+    var index = start
+    while index < end {
+        hash ^= UInt64(bytes[index])
+        hash &*= keyHashPrime
+        index += 1
+    }
+    return Int(truncatingIfNeeded: hash)
+}
+
+@inline(__always)
+func computeKeyHash(_ string: String) -> Int {
+    var hash = keyHashOffsetBasis
+    for byte in string.utf8 {
+        hash ^= UInt64(byte)
+        hash &*= keyHashPrime
+    }
+    return Int(truncatingIfNeeded: hash)
+}

--- a/Sources/TOMLDecoder/Parsing/TOMLDocument.swift
+++ b/Sources/TOMLDecoder/Parsing/TOMLDocument.swift
@@ -119,7 +119,7 @@ struct InternalTOMLTable: Equatable, Sendable {
     }
 
     func contains(source: TOMLDocument, key: String) -> Bool {
-        let keyHash = key.hashValue
+        let keyHash = computeKeyHash(key)
         for kv in keyValues {
             let pair = source.keyValues[kv]
             if pair.keyHash == keyHash, pair.key == key {


### PR DESCRIPTION
Switch key hashing to a lightweight FNV-1a hash and reuse normalized keys for dotted table/array creation to avoid repeated String hashing.
