### PR TITLE
Use fast key hash for parsing

### DIFF
--- a/Sources/TOMLDecoder/Parsing/TOMLDocument.swift
+++ b/Sources/TOMLDecoder/Parsing/TOMLDocument.swift
@@ -132,7 +132,7 @@ struct InternalTOMLTable: Equatable, Sendable {
     }
 
     func contains(source: TOMLDocument, key: String) -> Bool {
-        let keyHash = key.hashValue
+        let keyHash = fastKeyHash(key)
         for kv in keyValues {
             let pair = source.keyValues[kv]
             if pair.keyHash == keyHash, pair.key == key {


### PR DESCRIPTION
Replace String.hashValue with a lightweight FNV-1a hash for key
prefiltering to reduce hashing overhead during parse and table lookups.
