### PR TITLE
Use UInt8 storage for hot parser enums

### DIFF
--- a/Sources/TOMLDecoder/Parsing/TOMLDocument.swift
+++ b/Sources/TOMLDecoder/Parsing/TOMLDocument.swift
@@ -90,7 +90,7 @@ struct InternalTOMLArray: Equatable, Sendable {
         }
     }
 
-    enum Kind {
+    enum Kind: UInt8 {
         case value
         case array
         case table

--- a/Sources/TOMLDecoder/Parsing/Token.swift
+++ b/Sources/TOMLDecoder/Parsing/Token.swift
@@ -1,5 +1,5 @@
 struct Token: Equatable {
-    enum Kind {
+    enum Kind: UInt8 {
         case dot
         case comma
         case equal


### PR DESCRIPTION
Switch Token.Kind and InternalTOMLArray.Kind to UInt8-backed enums. The parser compares these enums in tight loops, and smaller enum storage can improve code generation and reduce data movement without changing semantics.
