### PR TITLE
Fix single value coding key context

### DIFF
--- a/Sources/TOMLDecoder/TOMLSingleValueDecodingContainer.Generated.swift
+++ b/Sources/TOMLDecoder/TOMLSingleValueDecodingContainer.Generated.swift
@@ -5,7 +5,16 @@ import Foundation
 
 extension _TOMLDecoder: SingleValueDecodingContainer {
     var context: TOMLKey {
-        codingPath.last as! TOMLKey
+        guard let key = codingPath.last else {
+            return TOMLKey.super
+        }
+        if let key = key as? TOMLKey {
+            return key
+        }
+        if let intValue = key.intValue {
+            return TOMLKey(intValue: intValue)
+        }
+        return TOMLKey(stringValue: key.stringValue)
     }
 
     @inline(__always)

--- a/Sources/TOMLDecoder/gyb/TOMLSingleValueDecodingContainer.swift.gyb
+++ b/Sources/TOMLDecoder/gyb/TOMLSingleValueDecodingContainer.swift.gyb
@@ -17,7 +17,16 @@ import Foundation
 
 extension _TOMLDecoder: SingleValueDecodingContainer {
     var context: TOMLKey {
-        codingPath.last as! TOMLKey
+        guard let key = codingPath.last else {
+            return TOMLKey.super
+        }
+        if let key = key as? TOMLKey {
+            return key
+        }
+        if let intValue = key.intValue {
+            return TOMLKey(intValue: intValue)
+        }
+        return TOMLKey(stringValue: key.stringValue)
     }
 
     % for native_type in native_types:

--- a/Tests/TOMLDecoderTests/TOMLDecoderTests.swift
+++ b/Tests/TOMLDecoderTests/TOMLDecoderTests.swift
@@ -144,6 +144,16 @@ struct TOMLDecoderTests {
         }
     }
 
+    @Test func optionalScalarArrayMismatchThrowsWithoutTrapping() throws {
+        struct Probe: Decodable {
+            let b: Bool?
+        }
+
+        #expect(throws: (any Error).self) {
+            try TOMLDecoder().decode(Probe.self, from: "b = [1, 2, 3]\n")
+        }
+    }
+
     @Test
     func foundationDateDecoding() throws {
         struct Player: Codable, Equatable {


### PR DESCRIPTION
## Summary
- Preserve the active coding key when single-value decoding throws from a keyed value.
- Regression coverage exercises the crash path through a keyed optional scalar mismatch.

## Validation
- Not run in this split branch per instruction; this commit was already verified before PR splitting.