### PR TITLE
Fix string accessor type mismatch

### DIFF
--- a/Sources/TOMLDecoder/Parsing/Parser.swift
+++ b/Sources/TOMLDecoder/Parsing/Parser.swift
@@ -1249,6 +1249,9 @@ extension Token {
         }
 
         let quoteChar = bytes[text.lowerBound]
+        if quoteChar != CodeUnits.doubleQuote, quoteChar != CodeUnits.singleQuote {
+            throw TOMLError(.typeMismatch(context: context, lineNumber: lineNumber, expected: "string"))
+        }
         var index = text.lowerBound
         var endIndex = text.upperBound
 

--- a/Tests/TOMLDecoderTests/TOMLTableKeyMembershipTests.swift
+++ b/Tests/TOMLDecoderTests/TOMLTableKeyMembershipTests.swift
@@ -35,4 +35,14 @@ struct TOMLTableKeyMembershipTests {
         #expect(table.contains(key: "c"))
         #expect(!table.contains(key: "d"))
     }
+
+    @Test
+    func stringAccessorMismatchInInlineTableThrowsWithoutTrapping() throws {
+        let table = try TOMLTable(source: "foo_bar = { x = 1 }\n")
+        let inlineTable = try table.table(forKey: "foo_bar")
+
+        #expect(throws: TOMLError.self) {
+            try inlineTable.string(forKey: "x")
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Throw a TOML type mismatch when string access sees a non-string token instead of letting the parser trap.
- Add regression coverage for inline table string accessor mismatch.

## Validation
- Not run in this split branch per instruction; this commit was already verified before PR splitting.