### PR TITLE
Fix sign-only integer unpacking

### DIFF
--- a/Sources/TOMLDecoder/Parsing/Parser.swift
+++ b/Sources/TOMLDecoder/Parsing/Parser.swift
@@ -1308,6 +1308,9 @@ extension Token {
             resultCodeUnits.append(bytes[index])
             index = text.index(after: index)
         }
+        guard index < text.upperBound else {
+            throw TOMLError(.invalidInteger(context: context, lineNumber: lineNumber, reason: "expected digit after sign"))
+        }
 
         if bytes[index] == CodeUnits.underscore {
             throw TOMLError(.invalidInteger(context: context, lineNumber: lineNumber, reason: "cannot start with a '_'"))

--- a/Tests/TOMLDecoderTests/TOMLTableKeyMembershipTests.swift
+++ b/Tests/TOMLDecoderTests/TOMLTableKeyMembershipTests.swift
@@ -45,4 +45,11 @@ struct TOMLTableKeyMembershipTests {
             try inlineTable.string(forKey: "x")
         }
     }
+
+    @Test
+    func signOnlyIntegerThrowsWithoutTrapping() throws {
+        #expect(throws: TOMLError.self) {
+            _ = try Dictionary(TOMLTable(source: "x = +\n"))
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Reject sign-only integer tokens before reading past the token bounds.
- Add regression coverage for `x = +`.

## Validation
- Not run in this split branch per instruction; this commit was already verified before PR splitting.