### PR TITLE
Fix base-prefixed integer unpacking

### DIFF
--- a/Sources/TOMLDecoder/Parsing/Parser.swift
+++ b/Sources/TOMLDecoder/Parsing/Parser.swift
@@ -1343,6 +1343,9 @@ extension Token {
             }
             // Single zero is allowed to continue to the main loop
         }
+        guard index < text.upperBound else {
+            throw TOMLError(.invalidInteger(context: context, lineNumber: lineNumber, reason: "expected digit after base prefix"))
+        }
 
         while index < text.upperBound {
             let ch = bytes[index]

--- a/Tests/TOMLDecoderTests/TOMLTableKeyMembershipTests.swift
+++ b/Tests/TOMLDecoderTests/TOMLTableKeyMembershipTests.swift
@@ -52,4 +52,11 @@ struct TOMLTableKeyMembershipTests {
             _ = try Dictionary(TOMLTable(source: "x = +\n"))
         }
     }
+
+    @Test
+    func basePrefixOnlyIntegerThrowsWithoutTrapping() throws {
+        #expect(throws: TOMLError.self) {
+            _ = try Dictionary(TOMLTable(source: "x = 0x\n"))
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- Reject base-prefixed integer tokens that omit digits before unpacking.
- Add regression coverage for `x = 0x`.

## Validation
- Not run in this split branch per instruction; this commit was already verified before PR splitting.