### PR TITLE
Test Swift 6.3.3 with Xcode 26.6

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -20,10 +20,10 @@ jobs:
             swift_version: "6.0"
           - os: ubuntu-24.04
             os_name: Ubuntu 24.04
-            swift_version: "6.2"
+            swift_version: "6.3.3"
           - os: windows-2025
             os_name: Windows 2025
-            swift_version: "6.2"
+            swift_version: "6.3.3"
     steps:
       - uses: SwiftyLab/setup-swift@latest
         with:
@@ -44,38 +44,41 @@ jobs:
             swift_version: "6.0"
           - os: macos-26
             os_name: macOS 26
-            swift_version: "6.2"
+            swift_version: "6.3.3"
     steps:
+      - name: Select Xcode
+        if: matrix.swift_version == '6.3.3'
+        run: sudo xcode-select -s /Applications/Xcode_26.6.app
       - name: Checkout source
         uses: actions/checkout@v4
       - name: Run tests
         run: swift test
 
   swift-test-simulator:
-    name: ${{ matrix.platform }} ${{ matrix.os_version }} (Swift 6.2)
+    name: ${{ matrix.platform }} ${{ matrix.os_version }} (Swift 6.3.3)
     runs-on: macos-26
     strategy:
       matrix:
         include:
           - platform: iOS
-            os_version: "26.1"
-            destination: "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.1"
+            os_version: "26.5"
+            destination: "platform=iOS Simulator,name=iPhone 17 Pro,OS=26.5"
             sdk: iphonesimulator
           - platform: tvOS
-            os_version: "26.1"
-            destination: "platform=tvOS Simulator,name=Apple TV,OS=26.1"
+            os_version: "26.5"
+            destination: "platform=tvOS Simulator,name=Apple TV,OS=26.5"
             sdk: appletvsimulator
           - platform: watchOS
-            os_version: "26.1"
-            destination: "platform=watchOS Simulator,name=Apple Watch Series 11 (46mm),OS=26.1"
+            os_version: "26.5"
+            destination: "platform=watchOS Simulator,name=Apple Watch Series 11 (46mm),OS=26.5"
             sdk: watchsimulator
           - platform: visionOS
-            os_version: "26.1"
-            destination: "platform=visionOS Simulator,name=Apple Vision Pro,OS=26.1"
+            os_version: "26.5"
+            destination: "platform=visionOS Simulator,name=Apple Vision Pro,OS=26.5"
             sdk: xrsimulator
     steps:
       - name: Select Xcode
-        run: sudo xcode-select -s /Applications/Xcode_26.1.1.app
+        run: sudo xcode-select -s /Applications/Xcode_26.6.app
       - name: List simulators
         run: xcrun simctl list devices
       - name: Checkout source


### PR DESCRIPTION
## Summary
- Move CI Swift 6.2 jobs to Swift 6.3.3.
- Select Xcode 26.6 for macOS 26 and Apple simulator jobs.
- Run Apple simulator verification against OS 26.5 destinations for iOS, tvOS, watchOS, and visionOS.

## Validation
- Parsed `.github/workflows/swift.yml` with Ruby YAML.