### PR TITLE
Update workflows for Node 24 actions

### DIFF
--- a/.github/workflows/benchmark-pr.yml
+++ b/.github/workflows/benchmark-pr.yml
@@ -23,7 +23,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
@@ -38,7 +38,7 @@ jobs:
           echo "/opt/homebrew/bin:/usr/local/bin" >> $GITHUB_PATH
 
       - name: Cache SwiftPM artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.swiftpm
@@ -81,12 +81,14 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Comment PR with benchmark result
-        if: ${{ env.hasBenchmark == '1' }}
-        uses: thollander/actions-comment-pull-request@v3
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          message: ${{ steps.benchmark.outputs.comment }}
-          comment-tag: execution
+        if: ${{ env.hasBenchmark == '1' && github.event_name == 'pull_request' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr comment "${{ github.event.pull_request.number }}" \
+            --body-file benchmark_comment.md \
+            --edit-last \
+            --create-if-none
 
       - name: Exit with correct status
         if: ${{ env.hasBenchmark == '1' }}

--- a/.github/workflows/build-wasm.yml
+++ b/.github/workflows/build-wasm.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           swift-version: 6.2
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Set up Swift for WASM
         run: swift sdk install https://download.swift.org/swift-6.2.3-release/wasm-sdk/swift-6.2.3-RELEASE/swift-6.2.3-RELEASE_wasm.artifactbundle.tar.gz --checksum 394040ecd5260e68bb02f6c20aeede733b9b90702c2204e178f3e42413edad2a
       - name: Run tests

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Make script executable
       run: chmod +x Scripts/test-generate.sh

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Cache SwiftPM artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.swiftpm

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           swift-version: ${{ matrix.swift_version }}
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Run tests
         run: swift test
 
@@ -50,7 +50,7 @@ jobs:
         if: matrix.swift_version == '6.3.3'
         run: sudo xcode-select -s /Applications/Xcode_26.6.app
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Run tests
         run: swift test
 
@@ -82,7 +82,7 @@ jobs:
       - name: List simulators
         run: xcrun simctl list devices
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Run tests (simulator)
         run: |
           xcodebuild -scheme TOMLDecoder-Package -destination "${{ matrix.destination }}" -sdk "${{ matrix.sdk }}" test
@@ -96,7 +96,7 @@ jobs:
       - name: List simulators
         run: xcrun simctl list devices
       - name: Checkout source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Run tests (simulator)
         run: |
           xcodebuild -scheme TOMLDecoder-Package -destination "platform=iOS Simulator,name=iPhone 15 Pro,OS=17.0.1" -sdk iphonesimulator test

--- a/.github/workflows/swiftformat.yml
+++ b/.github/workflows/swiftformat.yml
@@ -16,7 +16,7 @@ jobs:
 
     - name: Check for Swift file changes
       id: changes
-      uses: dorny/paths-filter@v3
+      uses: dorny/paths-filter@v4
       with:
         filters: |
           swift:
@@ -29,7 +29,7 @@ jobs:
 
     - name: Cache SwiftPM artifacts
       if: steps.changes.outputs.swift == 'true'
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ~/.swiftpm


### PR DESCRIPTION
## Summary
- update GitHub-provided actions to Node 24-compatible major versions
- update paths-filter to its Node 24-compatible major version
- replace the benchmark comment action with gh pr comment

## Verification
- parsed workflow YAML locally
- checked for remaining deprecated action references