### PR TITLE
Reject top-level single-value decoding

### DIFF
--- a/Sources/TOMLDecoder/_TOMLDecoder.swift
+++ b/Sources/TOMLDecoder/_TOMLDecoder.swift
@@ -51,7 +51,16 @@ final class _TOMLDecoder: Decoder {
     }
 
     func singleValueContainer() throws -> any SingleValueDecodingContainer {
-        self
+        guard token != .empty else {
+            throw DecodingError.typeMismatch(
+                (any SingleValueDecodingContainer).self,
+                DecodingError.Context(
+                    codingPath: codingPath,
+                    debugDescription: "Cannot decode a single value from a TOML table."
+                )
+            )
+        }
+        return self
     }
 
     init(referencing container: Container, at codingPath: [any CodingKey] = [], strategy: TOMLDecoder.Strategy, isLenient: Bool) {

--- a/Tests/TOMLDecoderTests/TOMLDecoderTests.swift
+++ b/Tests/TOMLDecoderTests/TOMLDecoderTests.swift
@@ -501,6 +501,12 @@ struct TOMLDecoderTests {
         #expect(result == Team(languages: [.swift, .mojo, .zig], favorite: .swift))
     }
 
+    @Test func topLevelTableCannotDecodeAsSingleValue() {
+        #expect(throws: DecodingError.self) {
+            try TOMLDecoder().decode(Int.self, from: "-1 = true")
+        }
+    }
+
     @Test func twitter() throws {
         _ = try TOMLDecoder().decode(TwitterArchive.self, from: Resources.twitterTOMLString)
     }


### PR DESCRIPTION
## Summary

- Reject single-value decoding requests when the decoder is wrapping a top-level TOML table.
- Return a `DecodingError.typeMismatch` instead of attempting to unpack an uninitialized token.
- Add a Swift Testing regression for decoding a top-level table as `Int`.

## Root cause

A top-level `TOMLDecoder` wraps a keyed `TOMLTable` and leaves its scalar token at the empty sentinel. When a scalar `Decodable` type requested a single-value container, the decoder returned itself and integer decoding indexed that empty token range, producing a `SIGTRAP` during decoder-fuzzer corpus initialization.

## Impact

Wrong-shape top-level decoding now fails normally with `DecodingError` instead of terminating the process. This allows the decoder fuzz target to load valid table-shaped corpus entries and continue fuzzing.

## Validation

- `swift test` — 750 tests passed.
- `swift test --filter TOMLDecoderTests.topLevelTableCannotDecodeAsSingleValue`
- Decoder libFuzzer startup corpus replay — 217 inputs passed without trapping.
- Multi-worker decoder fuzzing completed without crash artifacts.