### PR TITLE
Parse bare values in nested arrays

### DIFF
--- a/Sources/TOMLDecoder/Parsing/Parser.swift
+++ b/Sources/TOMLDecoder/Parsing/Parser.swift
@@ -774,7 +774,7 @@ struct Parser: ~Copyable {
             }
 
             switch token.kind {
-            case .string:
+            case .string, .bareKey:
                 if arrays[arrayIndex].kind == nil {
                     arrays[arrayIndex].kind = .value
                 } else if arrays[arrayIndex].kind != .value {

--- a/Tests/TOMLDecoderTests/TOMLDecoderTests.swift
+++ b/Tests/TOMLDecoderTests/TOMLDecoderTests.swift
@@ -348,6 +348,11 @@ struct TOMLDecoderTests {
         _ = try decoder.decode(LocalPlayer.self, from: toml)
     }
 
+    @Test(arguments: ["x = [[true]]", "x = [[inf]]"])
+    func nestedBooleanAndSpecialFloatArraysParse(_ toml: String) throws {
+        _ = try TOMLTable(source: toml)
+    }
+
     @Test func tomlIoExample() throws {
         let toml = """
         # This is a TOML document


### PR DESCRIPTION
## Summary

- accept bare scalar tokens while recursively parsing nested arrays
- cover nested Boolean and special-float values with parameterized regression tests

## Root cause

Recursive array parsing accepted only `.string` leaf tokens, while Boolean and special-float values are emitted as `.bareKey` tokens.

## Validation

- `swift test --filter TOMLDecoderTests.nestedBooleanAndSpecialFloatArraysParse`
- `swift test` (751 tests)

Closes #330